### PR TITLE
Fix working directory

### DIFF
--- a/app/client.php
+++ b/app/client.php
@@ -1,7 +1,7 @@
 #!/usr/bin/php
 <?php
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $message = file_get_contents("php://stdin");
 


### PR DESCRIPTION
When using the mailcatcher in my apache environment, sending mails failed, as the working directory was e.g. /var/www and the mail catcher script was not able to include the autoload file.
